### PR TITLE
Metodo agregar abono a gastos

### DIFF
--- a/src/finance/movimiento/entity/movimiento.entity.ts
+++ b/src/finance/movimiento/entity/movimiento.entity.ts
@@ -1,8 +1,9 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, ManyToMany, JoinTable, OneToOne } from 'typeorm';
 import { Usuario } from '../../../user/usuario/entity/usuario.entity';
 import { Categoria } from '../../categoria/entity/categoria.entity';
 import { Moneda } from '../../moneda/entity/moneda.entity';
 import { Tag } from 'src/finance/tag/entity/tag.entity';
+import { Abono } from 'src/finance/prestamo/abono/entity/abono.entity';
 
 
 
@@ -41,4 +42,8 @@ export class Movimiento {
     inverseJoinColumn: { name: 'id_tag' },
   })
   tags?: Tag[];
+
+  //relacion con abono (uno a uno)
+  @OneToOne(() => Abono, (abono) => abono.movimiento_generado)
+  abono?: Abono;
 }

--- a/src/finance/prestamo/abono/abono.controller.ts
+++ b/src/finance/prestamo/abono/abono.controller.ts
@@ -41,6 +41,15 @@ export class AbonoController {
   }
 
  
+  @Post(':id/generar-gasto')
+  @Roles('admin', 'usuario')
+  generarGasto(
+    @Param('id') id: string,
+    @CurrentUser() user: Usuario,
+  ) {
+    return this.abonoService.createGastoFromAbono(+id, user);
+  }
+
   @Patch(':id')
   @Roles('admin', 'usuario')
   update(
@@ -59,5 +68,11 @@ export class AbonoController {
     @CurrentUser() user: Usuario
   ) {
     return this.abonoService.remove(+id, user);
+  }
+
+  @Delete(':id/generar-gasto')
+  @Roles('admin', 'usuario')
+  revertirGasto(@Param('id') id: string, @CurrentUser() user: Usuario) {
+    return this.abonoService.revertGastoFromAbono(+id, user);
   }
 }

--- a/src/finance/prestamo/abono/abono.module.ts
+++ b/src/finance/prestamo/abono/abono.module.ts
@@ -5,10 +5,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Usuario } from 'src/user/usuario/entity/usuario.entity';
 import { Abono } from './entity/abono.entity';
 import { Prestamo } from '../prestamos/entity/prestamo.entity';
+import { Tag } from 'src/finance/tag/entity/tag.entity';
+import { Categoria } from 'src/finance/categoria/entity/categoria.entity';
+import { Movimiento } from 'src/finance/movimiento/entity/movimiento.entity';
 
 @Module({
   controllers: [AbonoController],
   providers: [AbonoService],
-  imports: [TypeOrmModule.forFeature([Usuario, Abono, Prestamo])],
+  imports: [TypeOrmModule.forFeature([Usuario, Abono, Prestamo, Tag, Categoria, Movimiento])],
 })
 export class AbonoModule {}

--- a/src/finance/prestamo/abono/abono.service.ts
+++ b/src/finance/prestamo/abono/abono.service.ts
@@ -1,11 +1,16 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository, IsNull } from 'typeorm';
 import { Abono } from './entity/abono.entity';
 import { CreateAbonoDto } from './dto/create-abono.dto';
 import { UpdateAbonoDto } from './dto/update-abono.dto';
 import { Usuario } from 'src/user/usuario/entity/usuario.entity';
 import { Prestamo } from '../prestamos/entity/prestamo.entity';
+import { Tag } from '../../tag/entity/tag.entity';
+import { Categoria } from 'src/finance/categoria/entity/categoria.entity';
+import { Movimiento } from 'src/finance/movimiento/entity/movimiento.entity';
+import { CreateMovimientoDto } from 'src/finance/movimiento/dto/create-movimiento.dto';
+import { Moneda } from 'src/finance/moneda/entity/moneda.entity';
 
 @Injectable()
 export class AbonoService {
@@ -15,6 +20,17 @@ export class AbonoService {
 
     @InjectRepository(Prestamo)
     private readonly prestamoRepo: Repository<Prestamo>,
+
+    @InjectRepository(Tag)
+    private readonly tagRepo: Repository<Tag>,
+
+    @InjectRepository(Categoria)
+    private readonly categoriaRepo: Repository<Categoria>,
+    
+    @InjectRepository(Movimiento)
+    private readonly movimientoRepo: Repository<Movimiento>,
+
+
   ) {}
 
   async findAll(user: Usuario): Promise<any> {
@@ -22,7 +38,6 @@ export class AbonoService {
       user.rol?.nombre === 'admin'
         ? {}
         : { prestamo: { usuario: { id_usuario: user.id_usuario } } };
-
     const abonos = await this.abonoRepo.find({
       where: whereCondition,
       relations: ['prestamo'],
@@ -156,4 +171,92 @@ export class AbonoService {
       data: abono,
     };
   }
+
+async createGastoFromAbono(id_abono: number, user: Usuario): Promise<CreateMovimientoDto> {
+    const abono = await this.abonoRepo.findOne({
+      where: { id_abono },
+      relations: ['prestamo', 'prestamo.usuario', 'movimiento_generado'],
+    });
+
+    if (!abono) throw new NotFoundException('Abono no encontrado');
+
+    if (abono.movimiento_generado) {
+        throw new BadRequestException('Este abono ya tiene un gasto asociado. Debes revertirlo primero si quieres crearlo de nuevo.');
+    }
+
+    const isAdmin = user.rol?.nombre === 'admin';
+    if (!isAdmin && abono.prestamo.usuario.id_usuario !== user.id_usuario) {
+      throw new NotFoundException('No tienes permisos sobre este abono');
+    }
+
+    const categoriaGasto = await this.categoriaRepo.findOne({
+      where: { tipo_categoria: 'gasto' } 
+    });
+
+    if (!categoriaGasto) {
+      throw new BadRequestException('No se encontró la categoría "gasto" en el sistema.');
+    }
+  
+    const tagAbono = await this.tagRepo.findOne({
+      where: [
+        { nombre: 'abono', usuario: IsNull() }, 
+        { nombre: 'abono', usuario: { id_usuario: user.id_usuario } } 
+      ]
+    });
+
+    const descripcion = `Abono del prestamo de '${abono.prestamo.prestamista}'`;
+    const tagsEntidades = tagAbono ? [tagAbono] : [];
+
+    const nuevoMovimiento = this.movimientoRepo.create({
+      monto: Number(abono.monto),
+      fecha: new Date(), 
+      descripcion: descripcion,
+      categoria: categoriaGasto,
+      usuario: user,
+      tags: tagsEntidades,
+    });
+
+    const movimientoGuardado = await this.movimientoRepo.save(nuevoMovimiento);
+    abono.movimiento_generado = movimientoGuardado;
+    await this.abonoRepo.save(abono);
+    const respuestaFrontend: CreateMovimientoDto = {
+      monto: Number(nuevoMovimiento.monto),
+      fecha: new Date().toISOString().split('T')[0], 
+      descripcion: nuevoMovimiento.descripcion,
+      id_categoria: categoriaGasto.id_categoria, 
+      id_usuario: user.id_usuario,
+      tags: tagsEntidades.map(t => t.id_tag),
+    };
+
+    return respuestaFrontend;
+  }
+
+  async revertGastoFromAbono(id_abono: number, user: Usuario): Promise<any> {
+    const abono = await this.abonoRepo.findOne({
+      where: { id_abono },
+      relations: ['prestamo', 'prestamo.usuario', 'movimiento_generado'],
+    });
+
+    if (!abono) throw new NotFoundException('Abono no encontrado');
+
+    const isAdmin = user.rol?.nombre === 'admin';
+    if (!isAdmin && abono.prestamo.usuario.id_usuario !== user.id_usuario) {
+      throw new NotFoundException('No tienes permisos sobre este abono');
+    }
+
+    if (!abono.movimiento_generado) {
+        throw new BadRequestException('Este abono no tiene ningún gasto registrado para eliminar.');
+    }
+
+    const idMovimientoABorrar = abono.movimiento_generado.id_movimiento; 
+    abono.movimiento_generado = undefined;
+    await this.abonoRepo.save(abono);
+    await this.movimientoRepo.delete(idMovimientoABorrar);
+
+    return {
+      message: 'Gasto asociado eliminado correctamente. El abono ahora está libre para registrarse de nuevo.'
+    };
+  }
 }
+
+

--- a/src/finance/prestamo/abono/entity/abono.entity.ts
+++ b/src/finance/prestamo/abono/entity/abono.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, OneToOne, JoinColumn } from 'typeorm';
 import { Prestamo } from '../../prestamos/entity/prestamo.entity';
+import { Movimiento } from 'src/finance/movimiento/entity/movimiento.entity';
 
 
 @Entity()
@@ -15,7 +16,9 @@ prestamo: Prestamo;
 @Column('decimal', { precision: 18, scale: 2 })
 monto: number;
 
-
+@OneToOne(() => Movimiento, { nullable: true, onDelete: 'SET NULL' })
+@JoinColumn({ name: 'id_movimiento_generado' }) 
+movimiento_generado?: Movimiento;
 
 @CreateDateColumn()
 fecha_creacion: Date;


### PR DESCRIPTION
###DESCRIPCION
Implementacion de 2 nuevos metodos para agruegar manualmente un abono creado a movimientos gastos, asi mismo la posibilidad de eliminar ese gasto sin modificar el abono incial
Se modificaron las entidades de abono y novimiento